### PR TITLE
Fix attributeBindings issue

### DIFF
--- a/lib/__tests__/__snapshots__/transform.js.snap
+++ b/lib/__tests__/__snapshots__/transform.js.snap
@@ -41,7 +41,7 @@ foo
     });
   
 ~~~~~~~~~~
-<div foo={{this.foo}} bar={{this.baz}} ...attributes>
+<div foo={{this.foo}} baz={{this.bar}} ...attributes>
   foo
 </div>
 =========="

--- a/lib/__tests__/find-properties.js
+++ b/lib/__tests__/find-properties.js
@@ -62,7 +62,7 @@ describe('findAttributeBindings()', () => {
   const TESTS = [
     ['', new Map()],
     ["attributeBindings: ['foo']", new Map([['foo', 'foo']])],
-    ["attributeBindings: ['foo:bar', 'BAZ']", new Map([['foo', 'bar'], ['BAZ', 'BAZ']])],
+    ["attributeBindings: ['foo:bar', 'BAZ']", new Map([['bar', 'foo'], ['BAZ', 'BAZ']])],
     ["attributeBindings: ''", /Unexpected `attributeBindings` value: ''/],
     ['attributeBindings: 5', /Unexpected `attributeBindings` value: 5/],
     ['attributeBindings: foo', /Unexpected `attributeBindings` value: foo/],

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -205,7 +205,7 @@ function transform(source, template, options = {}) {
   if (elementId) {
     attrs.push(b.attr('id', b.text(elementId)));
   }
-  attributeBindings.forEach((value, key) => {
+  attributeBindings.forEach((key, value) => {
     attrs.push(b.attr(key, b.mustache(`this.${value}`)));
   });
   if (classNodes.length === 1) {

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -205,7 +205,7 @@ function transform(source, template, options = {}) {
   if (elementId) {
     attrs.push(b.attr('id', b.text(elementId)));
   }
-  attributeBindings.forEach((key, value) => {
+  attributeBindings.forEach((value, key) => {
     attrs.push(b.attr(key, b.mustache(`this.${value}`)));
   });
   if (classNodes.length === 1) {
@@ -288,8 +288,8 @@ function findStringArrayProperties(properties, name) {
 function findAttributeBindings(properties) {
   let attrBindings = new Map();
   for (let binding of findStringArrayProperties(properties, 'attributeBindings')) {
-    let [from, to] = binding.split(':');
-    attrBindings.set(from, to || from);
+    let [value, attr] = binding.split(':');
+    attrBindings.set(attr || value, value);
   }
 
   return attrBindings;


### PR DESCRIPTION
It seems the logic for `attributeBindings` is currently inversed, more exactly
`attributeBindings: ['bar:baz']` should result in `<div baz={{this.bar}} ...attributes>`