### PR TITLE
Add support for passing paths or glob patterns as CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,42 @@ export default Component.extend({
 ```
 
 
+Configuration
+------------------------------------------------------------------------------
+
+### Paths
+
+By default, `tagless-ember-components-codemod` will process components in the
+following folders relatively to project root:
+
+```
+app/components
+addon/components
+```
+
+You may pass alternative paths or globs as arguments:
+
+```bash
+# process one component only
+npx tagless-ember-components-codemod app/components/my-component.js
+
+# process a component and all components under it's namespace
+npx tagless-ember-components-codemod app/components/my-component.js app/components/my-component/
+
+# process all components matching a glob
+npx tagless-ember-components-codemod app/components/**/foo-*.js
+```
+
+### Debug
+
+Debug logging could be enabled by setting `DEBUG` environment variable to
+`tagless-ember-components-codemod`:
+
+```bash
+DEBUG=tagless-ember-components-codemod npx tagless-ember-components-codemod
+```
+
+
 Known Caveats
 ------------------------------------------------------------------------------
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -5,7 +5,7 @@
 const chalk = require('chalk');
 const { run } = require('../lib/index');
 
-run().catch(error => {
+run(process.argv).catch(error => {
   process.exitCode = 1;
   console.error(chalk.red(error.stack));
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,21 +7,39 @@ const chalk = require('chalk');
 const SilentError = require('./silent-error');
 const { transformPath } = require('./transform');
 
-async function run() {
-  let path = await pkgDir();
-  await runForPath(path);
+async function run(argv) {
+  let patterns = argv.slice(2);
+  if (patterns.length !== 0) {
+    await runForGlobs(patterns, process.cwd());
+  } else {
+    let baseDir = await pkgDir();
+    await runForPath(baseDir);
+  }
 }
 
 async function runForPath(path, options = {}) {
   debug('runForPath(%o, %o)', path, options);
 
+  let patterns = ['app/components/**/*.js', 'addon/components/**/*.js'];
+  await runForGlobs(patterns, path, options);
+}
+
+async function runForGlobs(patterns, cwd, options = {}) {
+  debug('runForGlobs(%o, %o, %o)', patterns, cwd, options);
+
   let log = options.log || console.log;
 
   log(` 🔍  Searching for component files...`);
-  let paths = await globby(['app/components/**/*.js', 'addon/components/**/*.js'], { cwd: path });
+  let paths = await globby(patterns, {
+    cwd,
+    expandDirectories: {
+      extensions: ['js'],
+    },
+  });
   debug('componentPaths = %O', paths);
 
-  let pkgContent = fs.readFileSync(`${path}/package.json`);
+  let packageRoot = await pkgDir(cwd);
+  let pkgContent = fs.readFileSync(`${packageRoot}/package.json`);
   let pkg = JSON.parse(pkgContent);
   let hasComponentCSS =
     pkg.dependencies['ember-component-css'] || pkg.devDependencies['ember-component-css'];


### PR DESCRIPTION
Allows to convert only a subset of components or components, which location does not match the defaults.