### PR TITLE
Add support for `ariaRole` property

### DIFF
--- a/lib/__tests__/__snapshots__/transform.js.snap
+++ b/lib/__tests__/__snapshots__/transform.js.snap
@@ -23,6 +23,30 @@ foo
 =========="
 `;
 
+exports[`handles \`ariaRole\` correctly 1`] = `
+"==========
+
+    export default Component.extend({
+      ariaRole: 'button',
+    });
+  
+~~~~~~~~~~
+foo
+~~~~~~~~~~
+ => tagName: div
+~~~~~~~~~~
+
+    export default Component.extend({
+      tagName: \\"\\",
+    });
+  
+~~~~~~~~~~
+<div role=\\"button\\" ...attributes>
+  foo
+</div>
+=========="
+`;
+
 exports[`handles \`attributeBindings\` correctly 1`] = `
 "==========
 

--- a/lib/__tests__/transform.js
+++ b/lib/__tests__/transform.js
@@ -99,6 +99,18 @@ test('handles `classNameBindings` correctly', () => {
   expect(generateSnapshot(source, template)).toMatchSnapshot();
 });
 
+test('handles `ariaRole` correctly', () => {
+  let source = `
+    export default Component.extend({
+      ariaRole: 'button',
+    });
+  `;
+
+  let template = `foo`;
+
+  expect(generateSnapshot(source, template)).toMatchSnapshot();
+});
+
 test('throws if `Component.extend({ ... })` is not found', () => {
   let source = `
     export default class extends Component {
@@ -188,6 +200,20 @@ test('throws if component is using `click()`', () => {
 
   expect(() => transform(source, '')).toThrowErrorMatchingInlineSnapshot(
     `"Using \`click()\` is not supported in tagless components"`
+  );
+});
+
+test('throws if component is using a computed property for `ariaRole`', () => {
+  let source = `
+    export default Component.extend({
+      ariaRole: computed(function() {
+        return 'button';
+      }),
+    });
+  `;
+
+  expect(() => transform(source, '')).toThrowErrorMatchingInlineSnapshot(
+    `"Codemod does not support computed properties for \`ariaRole\`."`
   );
 });
 

--- a/lib/transform/classic.js
+++ b/lib/transform/classic.js
@@ -8,6 +8,7 @@ const {
   findClassNames,
   findClassNameBindings,
   findAttributeBindings,
+  findAriaRole,
   isMethod,
   isProperty,
 } = require('../utils');
@@ -124,6 +125,14 @@ module.exports = function transformClassicComponent(root, options) {
   let classNameBindings = findClassNameBindings(properties);
   debug('classNameBindings: %o', classNameBindings);
 
+  let ariaRole;
+  try {
+    ariaRole = findAriaRole(properties);
+  } catch (error) {
+    throw new SilentError('Codemod does not support computed properties for `ariaRole`.');
+  }
+  debug('ariaRole: %o', ariaRole);
+
   // set `tagName: ''`
   let tagNamePath = j(properties)
     .find(j.ObjectProperty)
@@ -145,11 +154,20 @@ module.exports = function transformClassicComponent(root, options) {
         isProperty(path, 'elementId') ||
         isProperty(path, 'attributeBindings') ||
         isProperty(path, 'classNames') ||
-        isProperty(path, 'classNameBindings')
+        isProperty(path, 'classNameBindings') ||
+        isProperty(path, 'ariaRole')
     )
     .remove();
 
   let newSource = root.toSource();
 
-  return { newSource, tagName, elementId, classNames, classNameBindings, attributeBindings };
+  return {
+    newSource,
+    tagName,
+    elementId,
+    classNames,
+    classNameBindings,
+    attributeBindings,
+    ariaRole,
+  };
 };

--- a/lib/transform/template.js
+++ b/lib/transform/template.js
@@ -8,7 +8,7 @@ const PLACEHOLDER = '@@@PLACEHOLDER@@@';
 
 module.exports = function transformTemplate(
   template,
-  { tagName, elementId, classNames, classNameBindings, attributeBindings },
+  { tagName, elementId, classNames, classNameBindings, attributeBindings, ariaRole },
   options
 ) {
   // wrap existing template with root element
@@ -30,6 +30,9 @@ module.exports = function transformTemplate(
   let attrs = [];
   if (elementId) {
     attrs.push(b.attr('id', b.text(elementId)));
+  }
+  if (ariaRole) {
+    attrs.push(b.attr('role', b.text(ariaRole)));
   }
   attributeBindings.forEach((value, key) => {
     attrs.push(b.attr(key, b.mustache(`this.${value}`)));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,6 +34,10 @@ function findElementId(properties) {
   return findStringProperty(properties, 'elementId');
 }
 
+function findAriaRole(properties) {
+  return findStringProperty(properties, 'ariaRole');
+}
+
 function findStringArrayProperties(properties, name) {
   let propertyPath = properties.filter(path => isProperty(path, name))[0];
   if (!propertyPath) {
@@ -99,6 +103,7 @@ module.exports = {
   isMethod,
   findStringProperty,
   findStringArrayProperties,
+  findAriaRole,
   findAttributeBindings,
   findClassNames,
   findClassNameBindings,


### PR DESCRIPTION
This adds support for `ariaRole` property:

- If it's value is a static string it's converted to a tagless component.
  ```js
  export default Component.extend({
    ariaRole: 'button',
  });
  ```
  is converted to
  ```hbs
  <div role="button"></div>
  ```
- If it's value is dynamic (most likely a computed property) the component is skipped. I expect this to be a rare edge case. So not doing the additional work to do it, might be okay.

This is kind of conflicting with #44. If support for native classes lands before, support for `ariaRole` in native classes needs to be added here. If this is merged before #44, support for `ariaRole` has to be added there. I don't care about the order.

Closes #49 