### PR TITLE
Fix empty package.json dependencies

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,8 @@ async function runForGlobs(patterns, cwd, options = {}) {
   let pkgContent = fs.readFileSync(`${packageRoot}/package.json`);
   let pkg = JSON.parse(pkgContent);
   let hasComponentCSS =
-    pkg.dependencies['ember-component-css'] || pkg.devDependencies['ember-component-css'];
+    (pkg.dependencies && pkg.dependencies['ember-component-css']) ||
+    (pkg.devDependencies && pkg.devDependencies['ember-component-css']);
 
   for (let path of paths) {
     try {


### PR DESCRIPTION
Extracted from https://github.com/ember-codemods/tagless-ember-components-codemod/pull/45

This PR fixes the case where the `package.json` file does not have `dependencies` or `devDependencies` keys.