### PR TITLE
Handle static class name bindings

### DIFF
--- a/lib/__tests__/__snapshots__/transform.js.snap
+++ b/lib/__tests__/__snapshots__/transform.js.snap
@@ -97,7 +97,7 @@ exports[`classic components handles \`classNameBindings\` correctly 1`] = `
 "==========
 
     export default Component.extend({
-      classNameBindings: ['a:b', 'x:y:z', 'foo::bar'],
+      classNameBindings: ['a:b', 'x:y:z', 'foo::bar', ':static'],
     });
   
 ~~~~~~~~~~
@@ -111,7 +111,7 @@ foo
     });
   
 ~~~~~~~~~~
-<div class=\\"{{if this.a \\"b\\"}} {{if this.x \\"y\\" \\"z\\"}} {{unless this.foo \\"bar\\"}}\\" ...attributes>
+<div class=\\"{{if this.a \\"b\\"}} {{if this.x \\"y\\" \\"z\\"}} {{unless this.foo \\"bar\\"}} static\\" ...attributes>
   foo
 </div>
 =========="
@@ -447,7 +447,7 @@ exports[`native components handles \`@classNameBindings\` correctly 1`] = `
       import Component from '@ember/component';
       import { classNameBindings } from '@ember-decorators/component';
 
-      @classNameBindings('a:b', 'x:y:z', 'foo::bar')
+      @classNameBindings('a:b', 'x:y:z', 'foo::bar', ':static')
       export default class FooComponent extends Component {
       }
     
@@ -465,7 +465,7 @@ foo
       }
     
 ~~~~~~~~~~
-<div class=\\"{{if this.a \\"b\\"}} {{if this.x \\"y\\" \\"z\\"}} {{unless this.foo \\"bar\\"}}\\" ...attributes>
+<div class=\\"{{if this.a \\"b\\"}} {{if this.x \\"y\\" \\"z\\"}} {{unless this.foo \\"bar\\"}} static\\" ...attributes>
   foo
 </div>
 =========="

--- a/lib/__tests__/transform.js
+++ b/lib/__tests__/transform.js
@@ -101,7 +101,7 @@ describe('classic components', function() {
   test('handles `classNameBindings` correctly', () => {
     let source = `
     export default Component.extend({
-      classNameBindings: ['a:b', 'x:y:z', 'foo::bar'],
+      classNameBindings: ['a:b', 'x:y:z', 'foo::bar', ':static'],
     });
   `;
 
@@ -447,7 +447,7 @@ describe('native components', function() {
       import Component from '@ember/component';
       import { classNameBindings } from '@ember-decorators/component';
 
-      @classNameBindings('a:b', 'x:y:z', 'foo::bar')
+      @classNameBindings('a:b', 'x:y:z', 'foo::bar', ':static')
       export default class FooComponent extends Component {
       }
     `;

--- a/lib/transform/template.js
+++ b/lib/transform/template.js
@@ -22,6 +22,8 @@ module.exports = function transformTemplate(
   classNameBindings.forEach(([truthy, falsy], property) => {
     if (!truthy) {
       classNodes.push(b.mustache(`unless this.${property} "${falsy}"`));
+    } else if (!property) {
+      classNodes.push(b.text(truthy));
     } else {
       classNodes.push(b.mustache(`if this.${property} "${truthy}"${falsy ? ` "${falsy}"` : ''}`));
     }


### PR DESCRIPTION
When combining static and dynamic classes it's possible to use :static
to insert an always truthy class name that doesn't depend on any
property. This is now handled correctly in the template output.